### PR TITLE
Fixes to description pages for network data

### DIFF
--- a/Datasets Description/Network/http.html
+++ b/Datasets Description/Network/http.html
@@ -94,14 +94,14 @@
       <td>71345</td>
     </tr>
     <tr>
-      <th>request_ body_len</th>
+      <th>request_body_len</th>
       <td>int64</td>
       <td>2048442</td>
       <td>707</td>
       <td>0</td>
     </tr>
     <tr>
-      <th>response_ body_len</th>
+      <th>response_body_len</th>
       <td>int64</td>
       <td>2048442</td>
       <td>3839</td>

--- a/Datasets Description/Network/ssh.html
+++ b/Datasets Description/Network/ssh.html
@@ -53,35 +53,63 @@
     </tr>
     <tr>
       <th>status</th>
-      <td>float64</td>
-      <td>0</td>
-      <td>0</td>
+      <td>object</td>
       <td>7143</td>
+      <td>3</td>
+      <td>0</td>
     </tr>
     <tr>
       <th>direction</th>
-      <td>float64</td>
-      <td>0</td>
-      <td>0</td>
+      <td>object</td>
       <td>7143</td>
+      <td>1</td>
+      <td>0</td>
     </tr>
     <tr>
       <th>client</th>
-      <td>float64</td>
-      <td>0</td>
-      <td>0</td>
-      <td>7143</td>
+      <td>object</td>
+      <td>3998</td>
+      <td>20</td>
+      <td>3145</td>
     </tr>
     <tr>
       <th>server</th>
-      <td>float64</td>
-      <td>0</td>
-      <td>0</td>
+      <td>object</td>
       <td>7143</td>
+      <td>9</td>
+      <td>0</td>
     </tr>
     <tr>
       <th>resp_size</th>
       <td>float64</td>
+      <td>0</td>
+      <td>0</td>
+      <td>7143</td>
+    </tr>
+    <tr>
+      <th>unknown1</th>
+      <td>object</td>
+      <td>0</td>
+      <td>0</td>
+      <td>7143</td>
+    </tr>
+    <tr>
+      <th>unknown2</th>
+      <td>object</td>
+      <td>0</td>
+      <td>0</td>
+      <td>7143</td>
+    </tr>
+    <tr>
+      <th>unknown3</th>
+      <td>object</td>
+      <td>0</td>
+      <td>0</td>
+      <td>7143</td>
+    </tr>
+    <tr>
+      <th>unknown4</th>
+      <td>object</td>
       <td>0</td>
       <td>0</td>
       <td>7143</td>


### PR DESCRIPTION
Two commits:

- Removed spaces from attribute names on http page
- Corrected datatypes and counts, and added missing columns on ssh page